### PR TITLE
import * in __init__.py

### DIFF
--- a/src/xirr/__init__.py
+++ b/src/xirr/__init__.py
@@ -9,3 +9,5 @@ except DistributionNotFound:
     __version__ = 'unknown'
 finally:
     del get_distribution, DistributionNotFound
+
+from .math import *

--- a/src/xirr/__init__.py
+++ b/src/xirr/__init__.py
@@ -10,4 +10,4 @@ except DistributionNotFound:
 finally:
     del get_distribution, DistributionNotFound
 
-from .math import *
+from .math import * # noqa F401


### PR DESCRIPTION
This PR adds `from .math import *` to [src/xirr/__init__.py#L13](https://github.com/JackLangerman/xirr/blob/7bc47aedd728073bc29c89c6e73267526364607f/src/xirr/__init__.py#L13) so that when one performs `pip install xirr` they can 
```python
import xirr
...
r = xirr.xirr(valuesPerDate)
``` 
.