### PR TITLE
Repl format

### DIFF
--- a/src/xirr/math.py
+++ b/src/xirr/math.py
@@ -18,15 +18,11 @@ def xnpv(valuesPerDate, rate):
     >>> xnpv(valuesPerDate, -0.10)
     22.257507852701295
     '''
-
     if rate == -1.0:
         return float('inf')
-
     t0 = min(valuesPerDate.keys())
-
     if rate <= -1.0:
         return sum([-abs(vi) / (-1.0 - rate)**((ti - t0).days / DAYS_PER_YEAR) for ti, vi in valuesPerDate.items()])
-
     return sum([vi / (1.0 + rate)**((ti - t0).days / DAYS_PER_YEAR) for ti, vi in valuesPerDate.items()])
 
 
@@ -40,18 +36,15 @@ def xirr(valuesPerDate):
     '''
     if not valuesPerDate:
         return None
-
     if all(v >= 0 for v in valuesPerDate.values()):
         return float("inf")
     if all(v <= 0 for v in valuesPerDate.values()):
         return -float("inf")
-
     result = None
     try:
         result = scipy.optimize.newton(lambda r: xnpv(valuesPerDate, r), 0)
     except (RuntimeError, OverflowError):    # Failed to converge?
         result = scipy.optimize.brentq(lambda r: xnpv(valuesPerDate, r), -0.999999999999999, 1e20, maxiter=10**6)
-
     if not isinstance(result, complex):
         return result
     else:

--- a/src/xirr/math.py
+++ b/src/xirr/math.py
@@ -11,29 +11,39 @@ DAYS_PER_YEAR = 365.0
 
 
 def xnpv(valuesPerDate, rate):
-    '''Calculate the irregular net present value.
+    """Calculate the irregular net present value.
 
     >>> from datetime import date
     >>> valuesPerDate = {date(2019, 12, 31): -100, date(2020, 12, 31): 110}
     >>> xnpv(valuesPerDate, -0.10)
     22.257507852701295
-    '''
+    """
     if rate == -1.0:
-        return float('inf')
+        return float("inf")
     t0 = min(valuesPerDate.keys())
     if rate <= -1.0:
-        return sum([-abs(vi) / (-1.0 - rate)**((ti - t0).days / DAYS_PER_YEAR) for ti, vi in valuesPerDate.items()])
-    return sum([vi / (1.0 + rate)**((ti - t0).days / DAYS_PER_YEAR) for ti, vi in valuesPerDate.items()])
+        return sum(
+            [
+                -abs(vi) / (-1.0 - rate) ** ((ti - t0).days / DAYS_PER_YEAR)
+                for ti, vi in valuesPerDate.items()
+            ]
+        )
+    return sum(
+        [
+            vi / (1.0 + rate) ** ((ti - t0).days / DAYS_PER_YEAR)
+            for ti, vi in valuesPerDate.items()
+        ]
+    )
 
 
 def xirr(valuesPerDate):
-    '''Calculate the irregular internal rate of return.
+    """Calculate the irregular internal rate of return.
 
     >>> from datetime import date
     >>> valuesPerDate = {date(2019, 12, 31): -80005.8, date(2020, 3, 12): 65209.6}
     >>> xirr(valuesPerDate)
     -0.645363882724717
-    '''
+    """
     if not valuesPerDate:
         return None
     if all(v >= 0 for v in valuesPerDate.values()):
@@ -43,8 +53,10 @@ def xirr(valuesPerDate):
     result = None
     try:
         result = scipy.optimize.newton(lambda r: xnpv(valuesPerDate, r), 0)
-    except (RuntimeError, OverflowError):    # Failed to converge?
-        result = scipy.optimize.brentq(lambda r: xnpv(valuesPerDate, r), -0.999999999999999, 1e20, maxiter=10**6)
+    except (RuntimeError, OverflowError):  # Failed to converge?
+        result = scipy.optimize.brentq(
+            lambda r: xnpv(valuesPerDate, r), -0.999999999999999, 1e20, maxiter=10 ** 6
+        )
     if not isinstance(result, complex):
         return result
     else:
@@ -52,8 +64,7 @@ def xirr(valuesPerDate):
 
 
 def cleanXirr(valuesPerDate):
-    '''A "cleaned" version of the xirr which avoids returning a xirr for some extreme cases and ignores amounts which are almost 0.
-    '''
+    """A "cleaned" version of the xirr which avoids returning a xirr for some extreme cases and ignores amounts which are almost 0."""
     valuesPerDateCleaned = {}
     for date, amount in valuesPerDate.items():
         if round(amount, 2) != 0:
@@ -69,14 +80,14 @@ def cleanXirr(valuesPerDate):
 
 
 def listsXirr(dates, values, whichXirr=xirr):
-    '''A convenience function that takes two lists of dates and values rather than a combined dictionary.
+    """A convenience function that takes two lists of dates and values rather than a combined dictionary.
 
     Use whichXirr to select the actuall xirr function to use.
 
     Anti-pattern: Using a simple dictionary comprehension would not work, e.g.
     `xirr({d: v for d, v in zip(dates, values)})`
     Because this overwrites entries with identical dates.
-    '''
+    """
     valuesPerDate = {}
     for date, value in zip(dates, values):
         valuesPerDate[date] = valuesPerDate.get(date, 0) + value


### PR DESCRIPTION
Incredibly REPL generates `IndentationError: unexpected indent` on blank lines. Removing them allows code to run through REPL.